### PR TITLE
Feature/aqi levels

### DIFF
--- a/aqipy/aqhi_ca.py
+++ b/aqipy/aqhi_ca.py
@@ -6,9 +6,10 @@
             https://en.wikipedia.org/wiki/Air_Quality_Health_Index_(Canada)
 """
 
-from aqipy.utils import __get_aqi_texts, __added_risk
+from aqipy.utils import __get_aqi_texts, __added_risk, __get_aqi_level
 
 CA_AQHI = ((1, 3), (4, 6), (7, 10), (11, 11))
+CA_AQHI_LEVELS = ('low', 'moderate', 'high', 'very_high')
 
 CA_AQHI_GENERAL = (
     "Ideal air quality for outdoor activities.",
@@ -25,7 +26,8 @@ CA_AQHI_RISK = (
 )
 
 
-def get_aqhi(o3_3h: float, no2_3h: float, pm25_3h: float, pm10_3h: float) -> (float, str, str):
+def get_aqhi(o3_3h: float, no2_3h: float, pm25_3h: float, pm10_3h: float, with_level: bool = False) -> (
+float, str, str):
     """
     Calculates Canada AQHI
 
@@ -33,6 +35,7 @@ def get_aqhi(o3_3h: float, no2_3h: float, pm25_3h: float, pm10_3h: float) -> (fl
     :param no2_3h: NO2 average (3h), ppm
     :param pm25_3h: PM2.5 average (3h), μg/m3
     :param pm10_3h: PM10 average (3h), μg/m3
+    :param with_level: Boolean distinguishing whether to print AQI level such as 'good' or 'hazardous'
     :return: CA AQHI, General message, Risk message
     """
     betas = [0.000537, 0.000871, 0.000487, 0.000297]
@@ -44,4 +47,6 @@ def get_aqhi(o3_3h: float, no2_3h: float, pm25_3h: float, pm10_3h: float) -> (fl
     pm10 = max(1, min(CA_AQHI[-1][1], round(ar_pm10)))
     aqhi = max(pm25, pm10)
     text1, text2 = __get_aqi_texts(aqhi, CA_AQHI, CA_AQHI_GENERAL, CA_AQHI_RISK)
-    return aqhi, text1, text2
+    if not with_level:
+        return aqhi, text1, text2
+    return aqhi, __get_aqi_level(aqhi, CA_AQHI, CA_AQHI_LEVELS)

--- a/aqipy/aqhi_ca.py
+++ b/aqipy/aqhi_ca.py
@@ -6,10 +6,12 @@
             https://en.wikipedia.org/wiki/Air_Quality_Health_Index_(Canada)
 """
 
+from typing import Union, Tuple
+
 from aqipy.utils import __get_aqi_texts, __added_risk, __get_aqi_level
 
 CA_AQHI = ((1, 3), (4, 6), (7, 10), (11, 11))
-CA_AQHI_LEVELS = ('low', 'moderate', 'high', 'very_high')
+CA_AQHI_LEVELS = ('low', 'moderate', 'high', 'very high')
 
 CA_AQHI_GENERAL = (
     "Ideal air quality for outdoor activities.",
@@ -26,8 +28,8 @@ CA_AQHI_RISK = (
 )
 
 
-def get_aqhi(o3_3h: float, no2_3h: float, pm25_3h: float, pm10_3h: float, with_level: bool = False) -> (
-float, str, str):
+def get_aqhi(o3_3h: float, no2_3h: float, pm25_3h: float, pm10_3h: float, with_level: bool = False) -> Union[
+    Tuple[float, str, str], Tuple[float, dict]]:
     """
     Calculates Canada AQHI
 
@@ -49,4 +51,4 @@ float, str, str):
     text1, text2 = __get_aqi_texts(aqhi, CA_AQHI, CA_AQHI_GENERAL, CA_AQHI_RISK)
     if not with_level:
         return aqhi, text1, text2
-    return aqhi, __get_aqi_level(aqhi, CA_AQHI, CA_AQHI_LEVELS)
+    return aqhi, {'level': __get_aqi_level(aqhi, CA_AQHI, CA_AQHI_LEVELS)}

--- a/aqipy/aqi_au.py
+++ b/aqipy/aqi_au.py
@@ -6,9 +6,10 @@
             https://www.environment.nsw.gov.au/topics/air/understanding-air-quality-data/air-quality-index
 """
 
-from aqipy.utils import AQI_NOT_AVAILABLE, __get_aqi_texts, __round_down
+from aqipy.utils import AQI_NOT_AVAILABLE, __get_aqi_texts, __round_down, __get_aqi_level
 
 AU_AQI = ((0, 33), (34, 66), (67, 99), (100, 149), (150, 200), (201, 201))
+AU_AQI_LEVELS = ('very_good', 'good', 'fair', 'poor', 'very_poor', 'hazardous')
 
 AU_AQI_GENERAL = (
     "Enjoy normal activities",
@@ -120,8 +121,8 @@ def get_aqi_pm10_24h(pm10_24h: float) -> (int, str, str):
     return __get_aqi(cp, AU_PM10_NEPM_STANDARD_24H)
 
 
-def get_aqi(o3_1h: float = None, o3_4h: float = None, co_8h: float = None,
-            no2_1h: float = None, so2_24h: float = None, pm25_24h: float = None, pm10_24h: float = None) -> (int, {}):
+def get_aqi(o3_1h: float = None, o3_4h: float = None, co_8h: float = None, no2_1h: float = None, so2_24h: float = None,
+            pm25_24h: float = None, pm10_24h: float = None, with_level: bool = False) -> (int, {}):
     """
     Calculates AU AQI (Maximum from individual indexes)
 
@@ -132,6 +133,7 @@ def get_aqi(o3_1h: float = None, o3_4h: float = None, co_8h: float = None,
     :param so2_24h: SO2 average (24h), ppm
     :param pm25_24h: PM2.5 average (24h), μg/m3
     :param pm10_24h: PM10 average (24h), μg/m3
+    :param with_level: Boolean distinguishing whether to print AQI level such as 'good' or 'hazardous'
     :return: AU AQI, dict with tuples (Individual aqi, General message, Risk message)
              keys are: o3_1h, o3_4h, co_8h, no2_1h, so2_24h, pm25_24h, pm10_24h
              -1 means AQI is not available
@@ -153,4 +155,7 @@ def get_aqi(o3_1h: float = None, o3_4h: float = None, co_8h: float = None,
         aqi_data['pm10_24h'] = get_aqi_pm10_24h(pm10_24h)
     if len(aqi_data) == 0:
         return AQI_NOT_AVAILABLE, aqi_data
-    return max(list(map(lambda x: x[0], aqi_data.values()))), aqi_data
+    value = max(list(map(lambda x: x[0], aqi_data.values())))
+    if not with_level:
+        return value, aqi_data
+    return value, __get_aqi_level(value, AU_AQI, AU_AQI_LEVELS)

--- a/aqipy/aqi_au.py
+++ b/aqipy/aqi_au.py
@@ -9,7 +9,7 @@
 from aqipy.utils import AQI_NOT_AVAILABLE, __get_aqi_texts, __round_down, __get_aqi_level
 
 AU_AQI = ((0, 33), (34, 66), (67, 99), (100, 149), (150, 200), (201, 201))
-AU_AQI_LEVELS = ('very_good', 'good', 'fair', 'poor', 'very_poor', 'hazardous')
+AU_AQI_LEVELS = ('very good', 'good', 'fair', 'poor', 'very poor', 'hazardous')
 
 AU_AQI_GENERAL = (
     "Enjoy normal activities",
@@ -158,4 +158,4 @@ def get_aqi(o3_1h: float = None, o3_4h: float = None, co_8h: float = None, no2_1
     value = max(list(map(lambda x: x[0], aqi_data.values())))
     if not with_level:
         return value, aqi_data
-    return value, __get_aqi_level(value, AU_AQI, AU_AQI_LEVELS)
+    return value, {'level': __get_aqi_level(value, AU_AQI, AU_AQI_LEVELS)}

--- a/aqipy/aqi_cn.py
+++ b/aqipy/aqi_cn.py
@@ -9,7 +9,7 @@ from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formu
 
 CN_AQI = ((0, 50), (51, 100), (101, 150), (151, 200), (201, 299), (300, 300))
 CN_AQI_LEVELS = (
-'excellent', 'good', 'lightly_polluted', 'moderately_polluted', 'heavily_polluted', 'severely_polluted')
+    'excellent', 'good', 'lightly polluted', 'moderately polluted', 'heavily polluted', 'severely polluted')
 CN_AQI_EFFECTS = (
     "No health implications.",
     "Some pollutants may slightly affect very few hypersensitive individuals.",
@@ -150,4 +150,4 @@ int, {}):
     value = max(list(map(lambda x: x[0], aqi_data.values())))
     if not with_level:
         return value, aqi_data
-    return value, __get_aqi_level(value, CN_AQI, CN_AQI_LEVELS)
+    return value, {'level': __get_aqi_level(value, CN_AQI, CN_AQI_LEVELS)}

--- a/aqipy/aqi_cn.py
+++ b/aqipy/aqi_cn.py
@@ -5,9 +5,11 @@
     Source: https://core.ac.uk/download/pdf/38094372.pdf
 """
 
-from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts
+from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts, __get_aqi_level
 
 CN_AQI = ((0, 50), (51, 100), (101, 150), (151, 200), (201, 299), (300, 300))
+CN_AQI_LEVELS = (
+'excellent', 'good', 'lightly_polluted', 'moderately_polluted', 'heavily_polluted', 'severely_polluted')
 CN_AQI_EFFECTS = (
     "No health implications.",
     "Some pollutants may slightly affect very few hypersensitive individuals.",
@@ -111,7 +113,8 @@ def get_aqi_no2_24h(no2_24h: float) -> (int, str, str):
 
 
 def get_aqi(o3_1h: float = None, o3_8h: float = None, co_24h: float = None, pm25_24h: float = None,
-            pm10_24h: float = None, so2_24h: float = None, no2_24h: float = None) -> (int, {}):
+            pm10_24h: float = None, so2_24h: float = None, no2_24h: float = None, with_level: bool = False) -> (
+int, {}):
     """
     Calculates CN AQI (Maximum from individual indexes)
 
@@ -122,6 +125,7 @@ def get_aqi(o3_1h: float = None, o3_8h: float = None, co_24h: float = None, pm25
     :param pm10_24h: PM10 average (24h), μg/m3
     :param so2_24h: SO2 average (24h), ppm
     :param no2_24h: NO2 average (24h), ppm
+    :param with_level: Boolean distinguishing whether to print AQI level such as 'good' or 'hazardous'
     :return: CN AQI, dict with tuples (Individual aqi, Effect message, Caution message)
              keys are: o3_1h, o3_8h, co_24h, pm25_24h, pm10_24h, so2_24h, no2_24h
              -1 means AQI is not available
@@ -143,4 +147,7 @@ def get_aqi(o3_1h: float = None, o3_8h: float = None, co_24h: float = None, pm25
         aqi_data['no2_24h'] = get_aqi_no2_24h(no2_24h)
     if len(aqi_data) == 0:
         return AQI_NOT_AVAILABLE, aqi_data
-    return max(list(map(lambda x: x[0], aqi_data.values()))), aqi_data
+    value = max(list(map(lambda x: x[0], aqi_data.values())))
+    if not with_level:
+        return value, aqi_data
+    return value, __get_aqi_level(value, CN_AQI, CN_AQI_LEVELS)

--- a/aqipy/aqi_in.py
+++ b/aqipy/aqi_in.py
@@ -8,7 +8,7 @@
 from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts, __get_aqi_level
 
 IN_AQI = ((0, 50), (51, 100), (101, 250), (251, 350), (351, 400), (401, 500))
-IN_AQI_LEVELS = ('good', 'satisfactory', 'moderately_polluted', 'poor', 'very_poor', 'severe')
+IN_AQI_LEVELS = ('good', 'satisfactory', 'moderately polluted', 'poor', 'very poor', 'severe')
 IN_AQI_EFFECTS = (
     "Minimal impact",
     "May cause minor breathing discomfort to sensitive people.",
@@ -157,4 +157,4 @@ def get_aqi(o3_8h: float = None, co_8h: float = None, pm25_24h: float = None,
     value = max(list(map(lambda x: x[0], aqi_data.values())))
     if not with_level:
         return value, aqi_data
-    return value, __get_aqi_level(value, IN_AQI, IN_AQI_LEVELS)
+    return value, {'level': __get_aqi_level(value, IN_AQI, IN_AQI_LEVELS)}

--- a/aqipy/aqi_in.py
+++ b/aqipy/aqi_in.py
@@ -5,9 +5,10 @@
     Source: http://www.indiaenvironmentportal.org.in/files/file/Air%20Quality%20Index.pdf
 """
 
-from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts
+from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts, __get_aqi_level
 
 IN_AQI = ((0, 50), (51, 100), (101, 250), (251, 350), (351, 400), (401, 500))
+IN_AQI_LEVELS = ('good', 'satisfactory', 'moderately_polluted', 'poor', 'very_poor', 'severe')
 IN_AQI_EFFECTS = (
     "Minimal impact",
     "May cause minor breathing discomfort to sensitive people.",
@@ -117,7 +118,7 @@ def get_aqi_pm10_24h(pm10_24h: float) -> (int, str, str):
 
 def get_aqi(o3_8h: float = None, co_8h: float = None, pm25_24h: float = None,
             pm10_24h: float = None, so2_24h: float = None, no2_24h: float = None,
-            nh3_24h: float = None, pb_24h: float = None) -> (int, {}):
+            nh3_24h: float = None, pb_24h: float = None, with_level: bool = False) -> (int, {}):
     """
     Calculates India AQI (Maximum from individual indexes)
 
@@ -129,6 +130,7 @@ def get_aqi(o3_8h: float = None, co_8h: float = None, pm25_24h: float = None,
     :param no2_24h: NO2 average (24h), ppm
     :param nh3_24h: HN3 average (24h), ppm
     :param pb_24h: Pb average (24h), ppm
+    :param with_level: Boolean distinguishing whether to print AQI level such as 'good' or 'hazardous'
     :return: India AQI, dict with tuples (Individual aqi, Effect message, Caution message)
              keys are: o3_8h, co_8h, pm25_24h, pm10_24h, so2_24h, no2_24h, nh3_24h, pb_24h
              -1 means AQI is not available
@@ -152,4 +154,7 @@ def get_aqi(o3_8h: float = None, co_8h: float = None, pm25_24h: float = None,
         aqi_data['pb_24h'] = get_aqi_pb_24h(pb_24h)
     if len(aqi_data) == 0:
         return AQI_NOT_AVAILABLE, aqi_data
-    return max(list(map(lambda x: x[0], aqi_data.values()))), aqi_data
+    value = max(list(map(lambda x: x[0], aqi_data.values())))
+    if not with_level:
+        return value, aqi_data
+    return value, __get_aqi_level(value, IN_AQI, IN_AQI_LEVELS)

--- a/aqipy/aqi_us.py
+++ b/aqipy/aqi_us.py
@@ -8,7 +8,7 @@
 from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts, __get_aqi_level
 
 US_AQI = ((0, 50), (51, 100), (101, 150), (151, 200), (201, 300), (301, 500))
-US_AQI_LEVELS = ('good', 'moderate', 'unhealthy_sensitive', 'unhealthy', 'very_unhealthy', 'hazardous')
+US_AQI_LEVELS = ('good', 'moderate', 'unhealthy sensitive', 'unhealthy', 'very unhealthy', 'hazardous')
 US_OZONE_8H = ((0, 0.054), (0.055, 0.070), (0.071, 0.085), (0.086, 0.105), (0.106, 0.200))
 US_OZONE_1H = ((0, 0), (0, 0), (0.125, 0.164), (0.165, 0.204), (0.205, 0.404), (0.405, 0.604))
 US_OZONE_EFFECTS = (
@@ -229,4 +229,4 @@ def get_aqi(co_8h: float = None, o3_1h: float = None, o3_8h: float = None, no2_1
     value = max(list(map(lambda x: x[0], aqi_data.values())))
     if not with_level:
         return value, aqi_data
-    return value, __get_aqi_level(value, US_AQI, US_AQI_LEVELS)
+    return value, {'level': __get_aqi_level(value, US_AQI, US_AQI_LEVELS)}

--- a/aqipy/aqi_us.py
+++ b/aqipy/aqi_us.py
@@ -5,9 +5,10 @@
     Source: https://www.airnow.gov/sites/default/files/2018-05/aqi-technical-assistance-document-may2016.pdf
 """
 
-from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts
+from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts, __get_aqi_level
 
 US_AQI = ((0, 50), (51, 100), (101, 150), (151, 200), (201, 300), (301, 500))
+US_AQI_LEVELS = ('good', 'moderate', 'unhealthy_sensitive', 'unhealthy', 'very_unhealthy', 'hazardous')
 US_OZONE_8H = ((0, 0.054), (0.055, 0.070), (0.071, 0.085), (0.086, 0.105), (0.106, 0.200))
 US_OZONE_1H = ((0, 0), (0, 0), (0.125, 0.164), (0.165, 0.204), (0.205, 0.404), (0.405, 0.604))
 US_OZONE_EFFECTS = (
@@ -189,7 +190,7 @@ def get_aqi_no2_1h(no2_1h: float) -> (int, str, str):
 
 
 def get_aqi(co_8h: float = None, o3_1h: float = None, o3_8h: float = None, no2_1h: float = None, pm25_24h: float = None,
-            pm10_24h: float = None, so2_1h: float = None, so2_24h: float = None) -> (int, {}):
+            pm10_24h: float = None, so2_1h: float = None, so2_24h: float = None, with_level: bool = False) -> (int, {}):
     """
     Calculates US AQI (Maximum from individual indexes)
 
@@ -201,6 +202,7 @@ def get_aqi(co_8h: float = None, o3_1h: float = None, o3_8h: float = None, no2_1
     :param pm10_24h: PM10 average (24h), μg/m3
     :param so2_1h: SO2 average (1h), ppm
     :param so2_24h: SO2 average (24h), ppm
+    :param with_level: Boolean distinguishing whether to print AQI level such as 'good' or 'hazardous'
     :return: US AQI, dict with tuples (Individual aqi, Effect message, Caution message)
             keys are: co_8h, o3_1h, o3_8h, no2_1h, pm25_24h, pm10_24h, so2_1h, so2_24h
              -1 means AQI is not available
@@ -224,4 +226,7 @@ def get_aqi(co_8h: float = None, o3_1h: float = None, o3_8h: float = None, no2_1
         aqi_data['so2_24h'] = get_aqi_so2_24h(so2_24h)
     if len(aqi_data) == 0:
         return AQI_NOT_AVAILABLE, aqi_data
-    return max(list(map(lambda x: x[0], aqi_data.values()))), aqi_data
+    value = max(list(map(lambda x: x[0], aqi_data.values())))
+    if not with_level:
+        return value, aqi_data
+    return value, __get_aqi_level(value, US_AQI, US_AQI_LEVELS)

--- a/aqipy/cai_kr.py
+++ b/aqipy/cai_kr.py
@@ -8,7 +8,7 @@
 from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts, __get_aqi_level
 
 KR_CAI = ((0, 50), (51, 100), (101, 250), (251, 500))
-KR_CAI_LEVELS = ('good', 'moderate', 'unhealthy', 'very_unhealthy')
+KR_CAI_LEVELS = ('good', 'moderate', 'unhealthy', 'very unhealthy')
 KR_O3_1H = ((0, 0.03), (0.031, 0.09), (0.091, 0.15), (0.151, 0.6))
 KR_CO_1H = ((0, 2), (2.01, 9), (9.01, 15), (15.01, 50))
 KR_SO2_1H = ((0, 0.02), (0.021, 0.05), (0.051, 0.15), (0.151, 1))
@@ -124,4 +124,4 @@ def get_aqi(o3_1h: float = None, co_1h: float = None, so2_1h: float = None, no2_
     value = max(list(map(lambda x: x[0], aqi_data.values())))
     if not with_level:
         return value, aqi_data
-    return value, __get_aqi_level(value, KR_CAI, KR_CAI_LEVELS)
+    return value, {'level': __get_aqi_level(value, KR_CAI, KR_CAI_LEVELS)}

--- a/aqipy/cai_kr.py
+++ b/aqipy/cai_kr.py
@@ -5,9 +5,10 @@
     Source: http://www.airkorea.or.kr/eng/khaiInfo?pMENU_NO=166
 """
 
-from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts
+from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts, __get_aqi_level
 
 KR_CAI = ((0, 50), (51, 100), (101, 250), (251, 500))
+KR_CAI_LEVELS = ('good', 'moderate', 'unhealthy', 'very_unhealthy')
 KR_O3_1H = ((0, 0.03), (0.031, 0.09), (0.091, 0.15), (0.151, 0.6))
 KR_CO_1H = ((0, 2), (2.01, 9), (9.01, 15), (15.01, 50))
 KR_SO2_1H = ((0, 0.02), (0.021, 0.05), (0.051, 0.15), (0.151, 1))
@@ -90,7 +91,7 @@ def get_cai_pm10_24h(pm10_24h: float) -> (int, str, str):
 
 
 def get_aqi(o3_1h: float = None, co_1h: float = None, so2_1h: float = None, no2_1h: float = None,
-            pm25_24h: float = None, pm10_24h: float = None) -> (int, {}):
+            pm25_24h: float = None, pm10_24h: float = None, with_level: bool = False) -> (int, {}):
     """
     Calculates South Korea CAI (Maximum from individual indexes)
 
@@ -100,6 +101,7 @@ def get_aqi(o3_1h: float = None, co_1h: float = None, so2_1h: float = None, no2_
     :param no2_1h: NO2 average (1h), ppm
     :param pm25_24h: PM2.5 average (24h), μg/m3
     :param pm10_24h: PM10 average (24h), μg/m3
+    :param with_level: Boolean distinguishing whether to print AQI level such as 'good' or 'hazardous'
     :return: South Korea CAI, dict with tuples (Individual aqi, General message, Risk message)
              keys are: o3_1h, co_1h, so2_1h, no2_1h, pm25_24h, pm10_24h
              -1 means AQI is not available
@@ -119,4 +121,7 @@ def get_aqi(o3_1h: float = None, co_1h: float = None, so2_1h: float = None, no2_
         aqi_data['pm10_24h'] = get_cai_pm10_24h(pm10_24h)
     if len(aqi_data) == 0:
         return AQI_NOT_AVAILABLE, aqi_data
-    return max(list(map(lambda x: x[0], aqi_data.values()))), aqi_data
+    value = max(list(map(lambda x: x[0], aqi_data.values())))
+    if not with_level:
+        return value, aqi_data
+    return value, __get_aqi_level(value, KR_CAI, KR_CAI_LEVELS)

--- a/aqipy/caqi_eu.py
+++ b/aqipy/caqi_eu.py
@@ -8,7 +8,7 @@
 from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula, __get_aqi_level
 
 EU_CAQI = ((0, 24), (25, 49), (50, 74), (75, 99), (100, 100))
-EU_CAQI_LEVELS = ('very_low', 'low', 'medium', 'high', 'very_high')
+EU_CAQI_LEVELS = ('very low', 'low', 'medium', 'high', 'very high')
 EU_NO2_1H = ((0, 26), (27, 52), (53, 105), (106, 212), (213, 213))
 EU_PM10_1H = ((0, 24), (25, 49), (50, 89), (90, 179), (180, 180))
 EU_PM10_24H = ((0, 14), (15, 29), (30, 49), (50, 99), (100, 100))
@@ -148,4 +148,4 @@ def get_caqi(co_1h: float = None, o3_max_1h: float = None, no2_max_1h: float = N
     value = max(list(map(lambda x: x, aqi_data.values())))
     if not with_level:
         return value, aqi_data
-    return value, __get_aqi_level(value, EU_CAQI, EU_CAQI_LEVELS)
+    return value, {'level': __get_aqi_level(value, EU_CAQI, EU_CAQI_LEVELS)}

--- a/aqipy/caqi_eu.py
+++ b/aqipy/caqi_eu.py
@@ -5,9 +5,10 @@
     Source: https://www.airqualitynow.eu/download/CITEAIR-Comparing_Urban_Air_Quality_across_Borders.pdf
 """
 
-from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula
+from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula, __get_aqi_level
 
 EU_CAQI = ((0, 24), (25, 49), (50, 74), (75, 99), (100, 100))
+EU_CAQI_LEVELS = ('very_low', 'low', 'medium', 'high', 'very_high')
 EU_NO2_1H = ((0, 26), (27, 52), (53, 105), (106, 212), (213, 213))
 EU_PM10_1H = ((0, 24), (25, 49), (50, 89), (90, 179), (180, 180))
 EU_PM10_24H = ((0, 14), (15, 29), (30, 49), (50, 99), (100, 100))
@@ -107,7 +108,8 @@ def get_caqi_pm10_24h(pm10_24h: float) -> float:
 
 
 def get_caqi(co_1h: float = None, o3_max_1h: float = None, no2_max_1h: float = None, pm25_24h: float = None,
-             pm25_1h: float = None, pm10_1h: float = None, pm10_24h: float = None, so2_max_1h: float = None) -> (int, {}):
+             pm25_1h: float = None, pm10_1h: float = None, pm10_24h: float = None, so2_max_1h: float = None,
+             with_level: bool = False) -> (int, {}):
     """
     Calculates CAQI Europe (Maximum from individual indexes)
 
@@ -119,6 +121,7 @@ def get_caqi(co_1h: float = None, o3_max_1h: float = None, no2_max_1h: float = N
     :param pm10_1h: PM10 average (1h), μg/m3
     :param pm10_24h: PM10 average (24h), μg/m3
     :param so2_max_1h: SO2 maximum (max in 1h), ppm
+    :param with_level: Boolean distinguishing whether to print AQI level such as 'good' or 'hazardous'
     :return: CAQI Europe, dict with aqi values
             keys are: no2_1h, so2_1h, o3_1h, co_1h, pm25_1h, pm25_24h, pm10_1h, pm10_24h
              -1 means AQI is not available
@@ -142,4 +145,7 @@ def get_caqi(co_1h: float = None, o3_max_1h: float = None, no2_max_1h: float = N
         aqi_data['pm10_24h'] = get_caqi_pm10_24h(pm10_24h)
     if len(aqi_data) == 0:
         return AQI_NOT_AVAILABLE, aqi_data
-    return max(list(map(lambda x: x, aqi_data.values()))), aqi_data
+    value = max(list(map(lambda x: x, aqi_data.values())))
+    if not with_level:
+        return value, aqi_data
+    return value, __get_aqi_level(value, EU_CAQI, EU_CAQI_LEVELS)

--- a/aqipy/daqi_uk.py
+++ b/aqipy/daqi_uk.py
@@ -6,8 +6,11 @@
             https://uk-air.defra.gov.uk/assets/documents/reports/cat14/1304251155_Update_on_Implementation_of_the_DAQI_April_2013_Final.pdf
 """
 
-from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula, __get_aqi_general_formula_texts
+from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula, __get_aqi_general_formula_texts, \
+    __get_aqi_level
 
+UK_AQI = ((1, 3), (4, 6), (7, 9), (10, 10))
+UK_AQI_LEVELS = ('low', 'moderate', 'high', 'very_high')
 UK_O3_1H = ((0, 16), (17, 33), (34, 50), (51, 60), (61, 70), (71, 80), (81, 93), (94, 106), (107, 120), (121, 121))
 UK_NO2_1H = (
     (0, 35), (36, 71), (72, 106), (107, 142), (143, 177), (178, 212), (213, 248), (249, 284), (285, 319), (320, 320))
@@ -106,7 +109,7 @@ def get_aqi_pm10_24h(pm10_24h: float) -> (int, str, str):
 
 
 def get_daqi(o3_1h: float = None, no2_1h: float = None, so2_15m: float = None,
-            pm25_24h: float = None, pm10_24h: float = None) -> (int, {}):
+             pm25_24h: float = None, pm10_24h: float = None, with_level: bool = False) -> (int, {}):
     """
     Calculates DAQI UK (Maximum from individual indexes)
 
@@ -115,6 +118,7 @@ def get_daqi(o3_1h: float = None, no2_1h: float = None, so2_15m: float = None,
     :param so2_15m: SO3 average (15m), ppm
     :param pm25_24h: PM2.5 average (24h), μg/m3
     :param pm10_24h: PM10 average (24h), μg/m3
+    :param with_level: Boolean distinguishing whether to print AQI level such as 'good' or 'hazardous'
     :return: DAQI UK, dict with tuples (Individual aqi, Effect message, Caution message)
              keys are: o3_1h, no2_1h, so2_15m, pm25_24h, pm10_24h
              -1 means AQI is not available
@@ -132,4 +136,7 @@ def get_daqi(o3_1h: float = None, no2_1h: float = None, so2_15m: float = None,
         aqi_data['pm10_24h'] = get_aqi_pm10_24h(pm10_24h)
     if len(aqi_data) == 0:
         return AQI_NOT_AVAILABLE, aqi_data
-    return max(list(map(lambda x: x[0], aqi_data.values()))), aqi_data
+    value = max(list(map(lambda x: x[0], aqi_data.values())))
+    if not with_level:
+        return value, aqi_data
+    return value, __get_aqi_level(value, UK_AQI, UK_AQI_LEVELS)

--- a/aqipy/daqi_uk.py
+++ b/aqipy/daqi_uk.py
@@ -10,7 +10,7 @@ from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formu
     __get_aqi_level
 
 UK_AQI = ((1, 3), (4, 6), (7, 9), (10, 10))
-UK_AQI_LEVELS = ('low', 'moderate', 'high', 'very_high')
+UK_AQI_LEVELS = ('low', 'moderate', 'high', 'very high')
 UK_O3_1H = ((0, 16), (17, 33), (34, 50), (51, 60), (61, 70), (71, 80), (81, 93), (94, 106), (107, 120), (121, 121))
 UK_NO2_1H = (
     (0, 35), (36, 71), (72, 106), (107, 142), (143, 177), (178, 212), (213, 248), (249, 284), (285, 319), (320, 320))
@@ -139,4 +139,4 @@ def get_daqi(o3_1h: float = None, no2_1h: float = None, so2_15m: float = None,
     value = max(list(map(lambda x: x[0], aqi_data.values())))
     if not with_level:
         return value, aqi_data
-    return value, __get_aqi_level(value, UK_AQI, UK_AQI_LEVELS)
+    return value, {'level': __get_aqi_level(value, UK_AQI, UK_AQI_LEVELS)}

--- a/aqipy/psi_sg.py
+++ b/aqipy/psi_sg.py
@@ -7,9 +7,10 @@
             https://www-haze-gov-sg-admin.cwp.sg/docs/default-source/default-document-library/how-to-plan-your-outdoor-activities-during-haze.pdf
 """
 
-from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts
+from aqipy.utils import AQI_NOT_AVAILABLE, __round_down, __get_aqi_general_formula_texts, __get_aqi_level
 
 SG_PSI = ((0, 50), (51, 100), (101, 200), (201, 300), (301, 400), (401, 500))
+SG_PSI_LEVELS = ('good', 'moderate', 'unhealthy', 'unhealthy', 'hazardous', 'hazardous')
 SG_PM25_24H = ((0, 12), (13, 55), (56, 150), (151, 250), (251, 350), (351, 500))
 SG_PM10_24H = ((0, 50), (51, 150), (151, 350), (351, 420), (421, 500), (501, 600))
 SG_SO2_24H = ((0, 30), (31, 139), (140, 304), (305, 610), (611, 801), (802, 1000))
@@ -103,7 +104,7 @@ def get_psi_pm10_24h(pm10_24h: float) -> (int, str, str):
 
 
 def get_aqi(o3_8h: float = None, no2_1h: float = None, so2_24h: float = None,
-            co_8h: float = None, pm25_24h: float = None, pm10_24h: float = None, ) -> (int, {}):
+            co_8h: float = None, pm25_24h: float = None, pm10_24h: float = None, with_level: bool = False) -> (int, {}):
     """
     Calculates Singapore PSI (Maximum from individual indexes)
 
@@ -113,6 +114,7 @@ def get_aqi(o3_8h: float = None, no2_1h: float = None, so2_24h: float = None,
     :param co_8h: CO average (8h), ppm
     :param pm25_24h: PM2.5 average (24h), μg/m3
     :param pm10_24h: PM10 average (24h), μg/m3
+    :param with_level: Boolean distinguishing whether to print AQI level such as 'good' or 'hazardous'
     :return: Singapore PSI, dict with tuples (Individual PSI, General message, Risk message)
             keys are: o3_8h, no2_1h, so2_24h, co_8h, pm25_24h, pm10_24h
              -1 means AQI is not available
@@ -132,4 +134,7 @@ def get_aqi(o3_8h: float = None, no2_1h: float = None, so2_24h: float = None,
         aqi_data['pm10_24h'] = get_psi_pm10_24h(pm10_24h)
     if len(aqi_data) == 0:
         return AQI_NOT_AVAILABLE, aqi_data
-    return max(list(map(lambda x: x[0], aqi_data.values()))), aqi_data
+    value = max(list(map(lambda x: x[0], aqi_data.values())))
+    if not with_level:
+        return value, aqi_data
+    return value, __get_aqi_level(value, SG_PSI, SG_PSI_LEVELS)

--- a/aqipy/psi_sg.py
+++ b/aqipy/psi_sg.py
@@ -137,4 +137,4 @@ def get_aqi(o3_8h: float = None, no2_1h: float = None, so2_24h: float = None,
     value = max(list(map(lambda x: x[0], aqi_data.values())))
     if not with_level:
         return value, aqi_data
-    return value, __get_aqi_level(value, SG_PSI, SG_PSI_LEVELS)
+    return value, {'level': __get_aqi_level(value, SG_PSI, SG_PSI_LEVELS)}

--- a/aqipy/utils.py
+++ b/aqipy/utils.py
@@ -45,7 +45,6 @@ def __get_aqi_general_formula_texts(cp: float, av: [], a1: [], a2: [], aqi_a: []
     if max_aqi == 0:
         max_aqi = aqi_a[-1][1]
     t, i, bp = __get_index_data(cp, av, max_aqi, aqi_a)
-    print(bp)
     if t == len(aqi_a):
         text1, text2 = __get_aqi_texts(max_aqi, aqi_a, a1, a2)
         return max_aqi, text1, text2

--- a/aqipy/utils.py
+++ b/aqipy/utils.py
@@ -8,6 +8,8 @@ def __get_aqi_texts(aqi: int, aqi_a: [], a1: [], a2: []) -> (str, str):
     for i in range(len(aqi_a)):
         if aqi_a[i][0] <= aqi <= aqi_a[i][1]:
             return a1[i], a2[i]
+    if aqi > aqi_a[-1][1]:
+        return a1[-1], a2[-1]
     return "", ""
 
 
@@ -43,6 +45,7 @@ def __get_aqi_general_formula_texts(cp: float, av: [], a1: [], a2: [], aqi_a: []
     if max_aqi == 0:
         max_aqi = aqi_a[-1][1]
     t, i, bp = __get_index_data(cp, av, max_aqi, aqi_a)
+    print(bp)
     if t == len(aqi_a):
         text1, text2 = __get_aqi_texts(max_aqi, aqi_a, a1, a2)
         return max_aqi, text1, text2
@@ -56,3 +59,12 @@ def __get_aqi_general_formula_texts(cp: float, av: [], a1: [], a2: [], aqi_a: []
 def __added_risk(beta, c):
     ar = math.expm1(beta * float(c)) * 100.0
     return ar
+
+
+def __get_aqi_level(aqi, levels, levels_names):
+    for i in range(len(levels)):
+        if levels[i][0] <= aqi <= levels[i][1]:
+            return levels_names[i]
+    if aqi > levels[-1][1]:
+        return levels_names[-1]
+    return ""

--- a/tests/test_aqhi_ca.py
+++ b/tests/test_aqhi_ca.py
@@ -9,3 +9,14 @@ def test_get_aqi_ozone_8h():
     aqhi, text1, text2 = aqhi_ca.get_aqhi(0, 0, 0, 0)
     assert aqhi == 1
 
+def test_get_aqi_ozone_8h_with_level():
+    aqhi, data = aqhi_ca.get_aqhi(0.015, 0, 100, 20, True)
+    assert aqhi == 6
+    assert data.get('level') == 'moderate'
+    aqhi, data = aqhi_ca.get_aqhi(0, 0, 0, 0, True)
+    assert aqhi == 1
+    assert data.get('level') == 'low'
+
+
+def test_levels():
+    assert len(aqhi_ca.CA_AQHI) == len(aqhi_ca.CA_AQHI_LEVELS)

--- a/tests/test_aqi_au.py
+++ b/tests/test_aqi_au.py
@@ -19,6 +19,16 @@ def test_get_aqi_ozone_8h():
     assert aqi_data['co_8h'][0] == 56
 
 
+def test_get_aqi_ozone_8h_with_level():
+    aqi, aqi_data = aqi_au.get_aqi(o3_1h=0.07853333, with_level=True)
+    assert aqi == 70
+    assert aqi_data.get('level') == 'fair'
+
+
+def test_levels():
+    assert len(aqi_au.AU_AQI) == len(aqi_au.AU_AQI_LEVELS)
+
+
 def test_labels():
     assert len(aqi_au.AU_AQI) == len(aqi_au.AU_AQI_GENERAL)
     assert len(aqi_au.AU_AQI) == len(aqi_au.AU_AQI_RISK)

--- a/tests/test_aqi_cn.py
+++ b/tests/test_aqi_cn.py
@@ -19,6 +19,16 @@ def test_get_aqi_ozone_8h():
     assert aqi_data['co_24h'][0] == 60
 
 
+def test_get_aqi_ozone_8h_with_level():
+    aqi, aqi_data = aqi_cn.get_aqi(o3_8h=0.07853333, with_level=True)
+    assert aqi == 97
+    assert aqi_data.get('level') == 'good'
+
+
+def test_levels():
+    assert len(aqi_cn.CN_AQI) == len(aqi_cn.CN_AQI_LEVELS)
+
+
 def test_labels():
     assert len(aqi_cn.CN_AQI) == len(aqi_cn.CN_AQI_EFFECTS)
     assert len(aqi_cn.CN_AQI) == len(aqi_cn.CN_AQI_CAUTIONS)

--- a/tests/test_aqi_in.py
+++ b/tests/test_aqi_in.py
@@ -19,6 +19,16 @@ def test_get_aqi_ozone_8h():
     assert aqi_data['co_8h'][0] == 171
 
 
+def test_get_aqi_ozone_8h_with_level():
+    aqi, aqi_data = aqi_in.get_aqi(o3_8h=0.07853333, with_level=True)
+    assert aqi == 223
+    assert aqi_data.get('level') == 'moderately polluted'
+
+
+def test_levels():
+    assert len(aqi_in.IN_AQI) == len(aqi_in.IN_AQI_LEVELS)
+
+
 def test_labels():
     assert len(aqi_in.IN_AQI) == len(aqi_in.IN_AQI_EFFECTS)
 

--- a/tests/test_aqi_us.py
+++ b/tests/test_aqi_us.py
@@ -19,6 +19,16 @@ def test_get_aqi_ozone_8h():
     assert aqi_data['co_8h'][0] == 56
 
 
+def test_get_aqi_ozone_8h_with_level():
+    aqi, aqi_data = aqi_us.get_aqi(o3_8h=0.07853333, with_level=True)
+    assert aqi == 126
+    assert aqi_data.get('level') == 'unhealthy sensitive'
+
+
+def test_levels():
+    assert len(aqi_us.US_AQI) == len(aqi_us.US_AQI_LEVELS)
+
+
 def test_labels():
     assert len(aqi_us.US_AQI) == len(aqi_us.US_OZONE_EFFECTS)
     assert len(aqi_us.US_AQI) == len(aqi_us.US_OZONE_CAUTIONS)

--- a/tests/test_cai_kr.py
+++ b/tests/test_cai_kr.py
@@ -19,6 +19,16 @@ def test_get_aqi_ozone_8h():
     assert aqi_data['co_1h'][0] == 72
 
 
+def test_get_aqi_ozone_8h_with_level():
+    aqi, aqi_data = cai_kr.get_aqi(o3_1h=0.07853333, with_level=True)
+    assert aqi == 90
+    assert aqi_data.get('level') == 'moderate'
+
+
+def test_levels():
+    assert len(cai_kr.KR_CAI) == len(cai_kr.KR_CAI_LEVELS)
+
+
 def test_labels():
     assert len(cai_kr.KR_CAI) == len(cai_kr.KR_AQI_GENERAL)
 

--- a/tests/test_caqi_eu.py
+++ b/tests/test_caqi_eu.py
@@ -15,6 +15,16 @@ def test_get_caqi_ozone_8h():
     assert aqi_data['co_1h'] == 32
 
 
+def test_get_caqi_ozone_8h_with_level():
+    caqi, aqi_data = caqi_eu.get_caqi(o3_max_1h=0.07853333, with_level=True)
+    assert caqi == 65
+    assert aqi_data.get('level') == 'medium'
+
+
+def test_levels():
+    assert len(caqi_eu.EU_CAQI) == len(caqi_eu.EU_CAQI_LEVELS)
+
+
 def test_max():
     aqi = caqi_eu.get_caqi_o3_1h(100)
     assert aqi == 100

--- a/tests/test_daqi_uk.py
+++ b/tests/test_daqi_uk.py
@@ -17,6 +17,16 @@ def test_get_caqi_ozone_8h():
     assert aqi_data['pm25_24h'][0] == 1
 
 
+def test_get_caqi_ozone_8h_with_level():
+    caqi, aqi_data = daqi_uk.get_daqi(o3_1h=0.07853333, with_level=True)
+    assert caqi == 6
+    assert aqi_data.get('level') == 'moderate'
+
+
+def test_levels():
+    assert len(daqi_uk.UK_AQI) == len(daqi_uk.UK_AQI_LEVELS)
+
+
 def test_max():
     aqi, text1, text2 = daqi_uk.get_daqi_o3_1h(10)
     assert aqi == 10

--- a/tests/test_psi_sg.py
+++ b/tests/test_psi_sg.py
@@ -19,6 +19,16 @@ def test_get_psi_ozone_8h():
     assert aqi_data['co_8h'][0] == 57
 
 
+def test_get_psi_ozone_8h_with_level():
+    aqi, aqi_data = psi_sg.get_aqi(o3_8h=0.07853333, with_level=True)
+    assert aqi == 100
+    assert aqi_data.get('level') == 'moderate'
+
+
+def test_levels():
+    assert len(psi_sg.SG_PSI) == len(psi_sg.SG_PSI_LEVELS)
+
+
 def test_labels():
     assert len(psi_sg.SG_PSI) == len(psi_sg.SG_AQI_GENERAL)
     assert len(psi_sg.SG_PSI) == len(psi_sg.SG_AQI_RISK)


### PR DESCRIPTION
Добавил уровни aqi. В случае with_level=True специально не возвращаю словарь с детализацией по каждому параметру и рекомендации/предостережения, т.к. в текущий момент они не нужны нигде ни бэку ни фронту.

Hong Kong AQHI временно не трогал -- кажется что он сейчас делает не совсем правильные вещи. Из этой таблицы https://docs.google.com/spreadsheets/d/1Cp5C-3IcfsWRERuiw69o44ZA-dhWc2herA_odaxxSPI/edit#gid=468664368 и источников следует что aqhi должен быть целым числом соответсвующим промежутку в котором находится %AR. Например при %AR из (9.41, 11.28) значение aqhi должно быть 6, а в коде `aqhi = max(1, min(len(HK_AR), round(ar_total)))`. Так и было задумано?